### PR TITLE
Use correct value for FIX5

### DIFF
--- a/lkmm-fixes.patch
+++ b/lkmm-fixes.patch
@@ -7,7 +7,7 @@ index 6f5d518..577588e 100644
  static __always_inline void clear_pending(struct qspinlock *lock)
  {
 +#ifdef FIX5
-+    atomic_fetch_andnot_release(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
++    atomic_fetch_andnot_release(_Q_PENDING_VAL, &lock->val);
 +#else
  	atomic_andnot(_Q_PENDING_VAL, &lock->val);
 +#endif


### PR DESCRIPTION
The value used for `FIX5` was wrong (probably a copy paste error from `FIX4`) and was causing a liveness violation.
With this change, the verification of qspinlock (both safety and liveness) succeeds under LKMM even when we do not skip the pending logic (i.e. `-DSKIP_PENDING`) is not used.