### PR TITLE
Update dartagnan version and more exhaustive verification

### DIFF
--- a/dockerfiles/dartagnan.dockerfile
+++ b/dockerfiles/dartagnan.dockerfile
@@ -25,7 +25,7 @@ RUN cd home && \
 # Install Dat3M ################################################################
 RUN cd home && \
     git clone --branch cna-verification https://github.com/hernanponcedeleon/Dat3M.git && \
-    cd Dat3M && git checkout f9e2b2b85055854f80250e3456042c257f82f03c
+    cd Dat3M && git checkout 779a0e9bba3e30f8f1c883efc6d95e1eaae63861
 
 RUN if [ "${https_proxy}" ]; then \
         export https_host=`echo ${https_proxy} | cut -d: -f 2 | cut -d/ -f3`; \

--- a/scripts/dartagnan.sh
+++ b/scripts/dartagnan.sh
@@ -101,6 +101,7 @@ exec java -jar \
         --bound=1 \
         --program.processing.constantPropagation=false \
         --refinement.baseline=no_oota \
+        --encoding.wmm.idl2sat=true \
         --property=${properties} \
         --method=${method} \
         --solver=${smtsolver} \

--- a/scripts/docker-run-usecases.sh
+++ b/scripts/docker-run-usecases.sh
@@ -20,128 +20,191 @@ export DOCKER=1
 
 for solver in ${solvers}
 do
-    # 02    Verifying qspinlock under LKMM using Dartagnan,
+    # 02    Checking liveness of qspinlock under LKMM using Dartagnan,
     #       without applying any fix.
-    #       Expect to find a liveness violation [duration ~1 minute].
+    #       Expect to find a violation.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
         -p liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DSKIP_PENDING \
         client-code.c | tee results/out02-dartagnan-${solver}-lkmm-qspinlock-livenessviolation.txt
 
-    # 03    Verifying qspinlock under LKMM using Dartagnan,
+    # 03    Checking liveness of qspinlock under LKMM using Dartagnan,
     #       applying fix 1.
-    #       Expect to find a safety violation [duration ~2 minutes].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
-        -p reachability,liveness \
+        -p liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DSKIP_PENDING \
         -DFIX1 \
-        client-code.c | tee results/out03-dartagnan-${solver}-lkmm-qspinlock-safetyviolation.txt
+        client-code.c | tee results/out03-dartagnan-${solver}-lkmm-qspinlock-livenessfixed.txt
 
-    # 04    Verifying qspinlock under LKMM using Dartagnan,
-    #       applying fixes 1 and 2.
-    #       Expect no violation found and result [duration ~2 minutes].
+    # 04    Checking safety of qspinlock under LKMM using Dartagnan,
+    #       applying fix 1.
+    #       Expect to find a violation.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
-        -p reachability,liveness \
+        -p reachability \
+        -DALGORITHM=${QSPINLOCK_ALGORITHM} \
+        -DFIX1 \
+        client-code.c | tee results/out04-dartagnan-${solver}-lkmm-qspinlock-safetyviolation1.txt
+
+    # 05    Checking safety of qspinlock under LKMM using Dartagnan,
+    #       applying fixes 1 and 2.
+    #       Expect to find a violation.
+    ./scripts/dartagnan.sh \
+        -m lkmm \
+        -t ${solver} \
+        -p reachability \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
         -DSKIP_PENDING \
         -DFIX1 -DFIX2 \
-        client-code.c | tee results/out04-dartagnan-${solver}-lkmm-qspinlock-fixes.txt
+        client-code.c | tee results/out05-dartagnan-${solver}-lkmm-qspinlock-safetyviolation2.txt
 
-    # 05    Verifying qspinlock under Armv8 using Dartagnan,
+    # 06    Checking safety of qspinlock under LKMM using Dartagnan,
+    #       applying fixes 1, 2 and 3.
+    #       Expect to find a violation.
+    ./scripts/dartagnan.sh \
+        -m lkmm \
+        -t ${solver} \
+        -p reachability \
+        -DALGORITHM=${QSPINLOCK_ALGORITHM} \
+        -DFIX1 -DFIX2 -DFIX3 \
+        client-code.c | tee results/out06-dartagnan-${solver}-lkmm-qspinlock-safetyviolation3.txt
+
+    # 07    Checking safety of qspinlock under LKMM using Dartagnan,
+    #       applying fixes 1, 2, 3 and 4.
+    #       Expect to find a violation.
+    ./scripts/dartagnan.sh \
+        -m lkmm \
+        -t ${solver} \
+        -p reachability \
+        -DALGORITHM=${QSPINLOCK_ALGORITHM} \
+        -DFIX1 -DFIX2 -DFIX3 -DFIX4 \
+        client-code.c | tee results/out07-dartagnan-${solver}-lkmm-qspinlock-safetyviolation4.txt
+
+    # 08    Checking safety of qspinlock under LKMM using Dartagnan,
+    #       applying fixes 1, 2, 3, 4 and 5.
+    #       Expect no violation found and result UNKNOWN.
+    ./scripts/dartagnan.sh \
+        -m lkmm \
+        -t ${solver} \
+        -p reachability \
+        -DALGORITHM=${QSPINLOCK_ALGORITHM} \
+        -DFIX1 -DFIX2 -DFIX3 -DFIX4 -DFIX5 \
+        client-code.c | tee results/out08-dartagnan-${solver}-lkmm-qspinlock-safetyfixed.txt
+
+    # 09    Verifying qspinlock under Armv8 using Dartagnan,
     #       without applying any fix.
-    #       Expect no violation found and result UNKNOWN [duration ~3 minutes].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m armv8 \
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out05-dartagnan-${solver}-armv8-qspinlock.txt
+        client-code.c | tee results/out09-dartagnan-${solver}-armv8-qspinlock.txt
 
-    # 06    Verifying qspinlock under RISC-V using Dartagnan,
+    # 10    Verifying qspinlock under RISC-V using Dartagnan,
     #       without applying any fix.
-    #       Expect no violation found and result UNKNOWN [duration ~3 minutes].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m riscv \
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out06-dartagnan-${solver}-riscv-qspinlock.txt
+        client-code.c | tee results/out10-dartagnan-${solver}-riscv-qspinlock.txt
 
-    # 07    Verifying qspinlock on Power using Dartagnan,
+    # 11    Verifying qspinlock on Power using Dartagnan,
     #       without applying any fix.
-    #       Expect no violation found and result UNKNOWN [duration ~3 minutes].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m power \
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out07-dartagnan-${solver}-power-qspinlock.txt
+        client-code.c | tee results/out11-dartagnan-${solver}-power-qspinlock.txt
 
-    # 08    Verifying CNA under LKMM using Dartagnan,
+    # 12    Checking liveness of CNA under LKMM using Dartagnan,
     #       without applying any fix.
-    #       Expect to find a liveness violation [duration ~30 minutes].
+    #       Expect to find a violation.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
         -p liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
         -DSKIP_PENDING \
-        client-code.c | tee results/out08-dartagnan-${solver}-lkmm-cna-livenessviolation.txt
+        client-code.c | tee results/out12-dartagnan-${solver}-lkmm-cna-livenessviolation.txt
 
-    # 09    Verifying CNA under LKMM using Dartagnan,
-    #       applying fixes 1 and 2.
-    #       Expect no violation found and result UNKNOWN [duration ~16 hours].
+    # 13    Checking liveness of CNA under LKMM using Dartagnan,
+    #       without applying any fix.
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
-        -p reachability,liveness \
+        -p liveness \
+        -DALGORITHM=${CNA_ALGORITHM} \
+        -DSKIP_PENDING \
+        -DFIX1 \
+        client-code.c | tee results/out13-dartagnan-${solver}-lkmm-cna-livenessfixed.txt
+
+    # 14    Checking safety of CNA under LKMM using Dartagnan,
+    #       applying fix 1.
+    #       Expect no violation found and result UNKNOWN.
+    ./scripts/dartagnan.sh \
+        -m lkmm \
+        -t ${solver} \
+        -p reachability \
+        -DALGORITHM=${CNA_ALGORITHM} \
+        -DSKIP_PENDING \
+        -DFIX1 \
+        client-code.c | tee results/out14-dartagnan-${solver}-lkmm-cna-safetyviolation.txt
+
+    # 15    Checking safety of CNA under LKMM using Dartagnan,
+    #       applying fixes 1 and 2.
+    #       Expect no violation found and result UNKNOWN.
+    ./scripts/dartagnan.sh \
+        -m lkmm \
+        -t ${solver} \
+        -p reachability \
         -DALGORITHM=${CNA_ALGORITHM} \
         -DSKIP_PENDING \
         -DFIX1 -DFIX2 \
-        client-code.c | tee results/out09-dartagnan-${solver}-lkmm-cna-fixes.txt
+        client-code.c | tee results/out15-dartagnan-${solver}-lkmm-cna-safetyfixed.txt
 
-    # 10    Verifying CNA on Armv8 using Dartagnan,
+    # 16    Verifying CNA on Armv8 using Dartagnan,
     #       without applying any fix.
-    #       Expect no violation found and result UNKNOWN [duration ~12 hours].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m armv8 \
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
         -DSKIP_PENDING \
-        client-code.c | tee results/out10-dartagnan-${solver}-armv8-cna.txt
+        client-code.c | tee results/out16-dartagnan-${solver}-armv8-cna.txt
 
-    # 11    Verifying CNA on RISC-V using Dartagnan,
+    # 17    Verifying CNA on RISC-V using Dartagnan,
     #       without applying any fix.
-    #       Expect no violation found and result UNKNOWN [duration ~12 hours].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m riscv \
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
         -DSKIP_PENDING \
-        client-code.c | tee results/out11-dartagnan-${solver}-riscv-cna.txt
+        client-code.c | tee results/out17-dartagnan-${solver}-riscv-cna.txt
 
-    # 12    Verifying qspinlock on Power using Dartagnan,
+    # 18    Verifying qspinlock on Power using Dartagnan,
     #       without applying any fix.
-    #       Expect no violation found and result UNKNOWN [duration ~12 hours].
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m power \
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
         -DSKIP_PENDING \
-        client-code.c | tee results/out12-dartagnan-${solver}-power-cna.txt
+        client-code.c | tee results/out18-dartagnan-${solver}-power-cna.txt
 
 done


### PR DESCRIPTION
This PR
- updates the used version of dartagnan
- adds a new option to the script (based on the new version of dartagnan) which should improve verification times
- performs an exhaustive verification of qspinlock by removing the `-DSKIP_PENDING` flag
- adds some more test cases to, first fully fix liveness issues, and then one by one fix safety issues.

Notice that we are still skipping the pending logic for the CNA case. I am currently working on this (simply removing the flag does not work).