### PR TITLE
Cna no skip pending

### DIFF
--- a/scripts/docker-run-usecases.sh
+++ b/scripts/docker-run-usecases.sh
@@ -126,54 +126,18 @@ do
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
         client-code.c | tee results/out11-dartagnan-${solver}-power-qspinlock-both-none.txt
 
-    # 12    Checking liveness of CNA under LKMM using Dartagnan,
-    #       without applying any fix.
-    #       Expect to find a violation.
-    ./scripts/dartagnan.sh \
-        -m lkmm \
-        -t ${solver} \
-        -p liveness \
-        -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out12-dartagnan-${solver}-lkmm-cna-liveness-none.txt
-
-    # 13    Checking liveness of CNA under LKMM using Dartagnan,
-    #       without applying any fix.
+    # 12    Verifying CNA under LKMM using Dartagnan,
+    #       applying fixes 1, 2, 3, 4 and 5.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
-        -p liveness \
+        -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        -DFIX1 \
-        client-code.c | tee results/out13-dartagnan-${solver}-lkmm-cna-liveness-1.txt
+        -DFIX1 -DFIX2 -DFIX3 -DFIX4 -DFIX5 \
+        client-code.c | tee results/out12-dartagnan-${solver}-lkmm-cna-both-12345.txt
 
-    # 14    Checking safety of CNA under LKMM using Dartagnan,
-    #       applying fix 1.
-    #       Expect no violation found and result UNKNOWN.
-    ./scripts/dartagnan.sh \
-        -m lkmm \
-        -t ${solver} \
-        -p reachability \
-        -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        -DFIX1 \
-        client-code.c | tee results/out14-dartagnan-${solver}-lkmm-cna-safety-1.txt
-
-    # 15    Checking safety of CNA under LKMM using Dartagnan,
-    #       applying fixes 1 and 2.
-    #       Expect no violation found and result UNKNOWN.
-    ./scripts/dartagnan.sh \
-        -m lkmm \
-        -t ${solver} \
-        -p reachability \
-        -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        -DFIX1 -DFIX2 \
-        client-code.c | tee results/out15-dartagnan-${solver}-lkmm-cna-safety-2.txt
-
-    # 16    Verifying CNA on Armv8 using Dartagnan,
+    # 13    Verifying CNA on Armv8 using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -181,10 +145,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out16-dartagnan-${solver}-armv8-cna-both-none.txt
+        client-code.c | tee results/out13-dartagnan-${solver}-armv8-cna-both-none.txt
 
-    # 17    Verifying CNA on RISC-V using Dartagnan,
+    # 14    Verifying CNA on RISC-V using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -192,10 +155,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out17-dartagnan-${solver}-riscv-cna-both-none.txt
+        client-code.c | tee results/out14-dartagnan-${solver}-riscv-cna-both-none.txt
 
-    # 18    Verifying qspinlock on Power using Dartagnan,
+    # 15    Verifying qspinlock on Power using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -203,7 +165,6 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        -DSKIP_PENDING \
-        client-code.c | tee results/out18-dartagnan-${solver}-power-cna-both-none.txt
+        client-code.c | tee results/out15-dartagnan-${solver}-power-cna-both-none.txt
 
 done

--- a/verification-commit-recent.patch
+++ b/verification-commit-recent.patch
@@ -20,10 +20,10 @@ index d74b138..09a365e 100644
  
 -	queued_spin_lock_slowpath(lock, val);
 +#if defined(CONFIG_NUMA_AWARE_SPINLOCKS)
-+		/* We bypass the call (ignoring the boot argument). */
-+		__cna_queued_spin_lock_slowpath(lock, val);
++	/* We bypass the call (ignoring the boot argument). */
++	__cna_queued_spin_lock_slowpath(lock, val);
 +#else
-+		queued_spin_lock_slowpath(lock, val);
++	queued_spin_lock_slowpath(lock, val);
 +#endif /* defined(CONFIG_NUMA_AWARE_SPINLOCKS) */
  }
  #endif

--- a/verification-commit-recent.patch
+++ b/verification-commit-recent.patch
@@ -1,8 +1,34 @@
 diff --git a/include/asm-generic/qspinlock.h b/include/asm-generic/qspinlock.h
-index d74b138..a0bab6f 100644
+index d74b138..09a365e 100644
 --- a/include/asm-generic/qspinlock.h
 +++ b/include/asm-generic/qspinlock.h
-@@ -96,7 +96,11 @@ static __always_inline void queued_spin_unlock(struct qspinlock *lock)
+@@ -68,7 +68,11 @@ static __always_inline int queued_spin_trylock(struct qspinlock *lock)
+ 	return likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL));
+ }
+ 
++#if defined(CONFIG_NUMA_AWARE_SPINLOCKS)
++extern void __cna_queued_spin_lock_slowpath(struct qspinlock *lock, u32 val);
++#else
+ extern void queued_spin_lock_slowpath(struct qspinlock *lock, u32 val);
++#endif /* defined(CONFIG_NUMA_AWARE_SPINLOCKS) */
+ 
+ #ifndef queued_spin_lock
+ /**
+@@ -82,7 +86,12 @@ static __always_inline void queued_spin_lock(struct qspinlock *lock)
+ 	if (likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL)))
+ 		return;
+ 
+-	queued_spin_lock_slowpath(lock, val);
++#if defined(CONFIG_NUMA_AWARE_SPINLOCKS)
++		/* We bypass the call (ignoring the boot argument). */
++		__cna_queued_spin_lock_slowpath(lock, val);
++#else
++		queued_spin_lock_slowpath(lock, val);
++#endif /* defined(CONFIG_NUMA_AWARE_SPINLOCKS) */
+ }
+ #endif
+ 
+@@ -96,7 +105,11 @@ static __always_inline void queued_spin_unlock(struct qspinlock *lock)
  	/*
  	 * unlock() needs release semantics:
  	 */


### PR DESCRIPTION
This PR updates the verification patch to avoid skipping the pending logic in CNA.
It also updates our scripts to stop using `-DSKIP_PENDING`.