### PR TITLE
Update patches

### DIFF
--- a/client-code.c
+++ b/client-code.c
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 /*******************************************************************************
- * Run this client code with GenMC 0.7 to verify the correctness of the
+ * Run this client code with Dartagnan to verify the correctness of the
  * CNA slowpath of qspinlock (qspinlock_cna.h) from Linux 5.14.
  * The client code can be alternatively configured to use the MCS slowpath or
- * just the plain MCS lock (mcs_spinlock.h).
+ * an old version containing a liveness bug which is reproducible in hardware.
  ******************************************************************************/
 
 /* Number of threads */

--- a/dockerfiles/dartagnan.dockerfile
+++ b/dockerfiles/dartagnan.dockerfile
@@ -25,7 +25,7 @@ RUN cd home && \
 # Install Dat3M ################################################################
 RUN cd home && \
     git clone --branch cna-verification https://github.com/hernanponcedeleon/Dat3M.git && \
-    cd Dat3M && git checkout ce700dac6e9715785d4ef41db94986b0585fdb87
+    cd Dat3M && git checkout 0bc0268c7cd33b14e4db06a081509aeff77770ef
 
 RUN if [ "${https_proxy}" ]; then \
         export https_host=`echo ${https_proxy} | cut -d: -f 2 | cut -d/ -f3`; \

--- a/lkmm-fixes.patch
+++ b/lkmm-fixes.patch
@@ -20,7 +20,7 @@ index 70bd251..8878a33 100644
  static __always_inline void clear_pending_set_locked(struct qspinlock *lock)
  {
 -	atomic_add(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
-+#ifdef FIX3
++#ifdef FIX2
 +    atomic_fetch_add_release(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
 +#else
 +    atomic_add(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
@@ -46,7 +46,7 @@ index 70bd251..8878a33 100644
  	 * 0,0,* -> 0,1,* -> 0,0,1 pending, trylock
  	 */
 -	val = queued_fetch_set_pending_acquire(lock);
-+#ifdef FIX2
++#ifdef FIX3
 +    val = atomic_fetch_or_release(_Q_PENDING_VAL, &lock->val);
 +    smp_mb();
 +#else

--- a/lkmm-fixes.patch
+++ b/lkmm-fixes.patch
@@ -1,15 +1,16 @@
 diff --git a/kernel/locking/qspinlock.c b/kernel/locking/qspinlock.c
-index 70bd251..e917e27 100644
+index 70bd251..8878a33 100644
 --- a/kernel/locking/qspinlock.c
 +++ b/kernel/locking/qspinlock.c
 @@ -198,7 +198,11 @@ static __always_inline u32 xchg_tail(struct qspinlock *lock, u32 tail)
   */
  static __always_inline void clear_pending(struct qspinlock *lock)
  {
-+#ifdef FIX5
+-	atomic_andnot(_Q_PENDING_VAL, &lock->val);
++#ifdef FIX4
 +    atomic_fetch_andnot_release(_Q_PENDING_VAL, &lock->val);
 +#else
- 	atomic_andnot(_Q_PENDING_VAL, &lock->val);
++ 	atomic_andnot(_Q_PENDING_VAL, &lock->val);
 +#endif
  }
  
@@ -19,7 +20,7 @@ index 70bd251..e917e27 100644
  static __always_inline void clear_pending_set_locked(struct qspinlock *lock)
  {
 -	atomic_add(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
-+#ifdef FIX4
++#ifdef FIX3
 +    atomic_fetch_add_release(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
 +#else
 +    atomic_add(-_Q_PENDING_VAL + _Q_LOCKED_VAL, &lock->val);
@@ -32,7 +33,7 @@ index 70bd251..e917e27 100644
  		 * tail.
  		 */
 -		old = atomic_cmpxchg_relaxed(&lock->val, val, new);
-+#ifdef FIX2
++#ifdef FIX1
 +		old = atomic_cmpxchg_release(&lock->val, val, new);
 +#else
 +        old = atomic_cmpxchg_relaxed(&lock->val, val, new);
@@ -45,7 +46,7 @@ index 70bd251..e917e27 100644
  	 * 0,0,* -> 0,1,* -> 0,0,1 pending, trylock
  	 */
 -	val = queued_fetch_set_pending_acquire(lock);
-+#ifdef FIX3
++#ifdef FIX2
 +    val = atomic_fetch_or_release(_Q_PENDING_VAL, &lock->val);
 +    smp_mb();
 +#else
@@ -54,27 +55,3 @@ index 70bd251..e917e27 100644
  
  	/*
  	 * If we observe contention, there is a concurrent locker.
-@@ -468,8 +485,8 @@ pv_queue:
- 	 */
- 	barrier();
- 
--	node->locked = 0;
--	node->next = NULL;
-+    WRITE_ONCE(node->locked, 0);
-+    WRITE_ONCE(node->next, NULL);
- 	pv_init_node(node);
- 
- 	/*
-@@ -485,7 +502,11 @@ pv_queue:
- 	 * publish the updated tail via xchg_tail() and potentially link
- 	 * @node into the waitqueue via WRITE_ONCE(prev->next, node) below.
- 	 */
--	smp_wmb();
-+#ifdef FIX1
-+	smp_mb();
-+#else
-+    smp_wmb();
-+#endif
- 
- 	/*
- 	 * Publish the updated tail.

--- a/scripts/dartagnan.sh
+++ b/scripts/dartagnan.sh
@@ -101,7 +101,9 @@ exec java -jar \
         --bound=1 \
         --program.processing.constantPropagation=false \
         --refinement.baseline=no_oota \
+        --encoding.symmetry.breakOnRelation=rf \
         --encoding.wmm.idl2sat=true \
+        --modeling.threadCreateAlwaysSucceeds=true \
         --property=${properties} \
         --method=${method} \
         --solver=${smtsolver} \

--- a/scripts/docker-run-usecases.sh
+++ b/scripts/docker-run-usecases.sh
@@ -7,7 +7,7 @@ set -ex
 CNA_ALGORITHM=1
 QSPINLOCK_ALGORITHM=2
 
-solvers="yices2 mathsat5 Z3"
+solvers="yices2 mathsat5 z3"
 
 make docker_build
 
@@ -32,7 +32,7 @@ do
 
     # 03    Checking liveness of qspinlock under LKMM using Dartagnan,
     #       applying fix 1.
-    #       Expect no violation found and result UNKNOWN.
+    #       Expect to find a violation.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
@@ -41,16 +41,16 @@ do
         -DFIX1 \
         client-code.c | tee results/out03-dartagnan-${solver}-lkmm-qspinlock-liveness-1.txt
 
-    # 04    Checking safety of qspinlock under LKMM using Dartagnan,
-    #       applying fix 1.
-    #       Expect to find a violation.
+    # 04    Checking liveness of qspinlock under LKMM using Dartagnan,
+    #       applying fix 1 and 2.
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
-        -p reachability \
+        -p liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DFIX1 \
-        client-code.c | tee results/out04-dartagnan-${solver}-lkmm-qspinlock-safety-1.txt
+        -DFIX1 -DFIX2 \
+        client-code.c | tee results/out04-dartagnan-${solver}-lkmm-qspinlock-liveness-12.txt
 
     # 05    Checking safety of qspinlock under LKMM using Dartagnan,
     #       applying fixes 1 and 2.
@@ -76,7 +76,7 @@ do
 
     # 07    Checking safety of qspinlock under LKMM using Dartagnan,
     #       applying fixes 1, 2, 3 and 4.
-    #       Expect to find a violation.
+    #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
         -m lkmm \
         -t ${solver} \
@@ -85,18 +85,7 @@ do
         -DFIX1 -DFIX2 -DFIX3 -DFIX4 \
         client-code.c | tee results/out07-dartagnan-${solver}-lkmm-qspinlock-safety-1234.txt
 
-    # 08    Checking safety of qspinlock under LKMM using Dartagnan,
-    #       applying fixes 1, 2, 3, 4 and 5.
-    #       Expect no violation found and result UNKNOWN.
-    ./scripts/dartagnan.sh \
-        -m lkmm \
-        -t ${solver} \
-        -p reachability \
-        -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        -DFIX1 -DFIX2 -DFIX3 -DFIX4 -DFIX5 \
-        client-code.c | tee results/out08-dartagnan-${solver}-lkmm-qspinlock-safety-12345.txt
-
-    # 09    Verifying qspinlock under Armv8 using Dartagnan,
+    # 08    Verifying qspinlock under Armv8 using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -104,9 +93,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        client-code.c | tee results/out09-dartagnan-${solver}-armv8-qspinlock-both-none.txt
+        client-code.c | tee results/out08-dartagnan-${solver}-armv8-qspinlock-both-none.txt
 
-    # 10    Verifying qspinlock under RISC-V using Dartagnan,
+    # 09    Verifying qspinlock under RISC-V using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -114,9 +103,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        client-code.c | tee results/out10-dartagnan-${solver}-riscv-qspinlock-both-none.txt
+        client-code.c | tee results/out09-dartagnan-${solver}-riscv-qspinlock-both-none.txt
 
-    # 11    Verifying qspinlock on Power using Dartagnan,
+    # 10    Verifying qspinlock on Power using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -124,9 +113,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${QSPINLOCK_ALGORITHM} \
-        client-code.c | tee results/out11-dartagnan-${solver}-power-qspinlock-both-none.txt
+        client-code.c | tee results/out10-dartagnan-${solver}-power-qspinlock-both-none.txt
 
-    # 12    Verifying CNA under LKMM using Dartagnan,
+    # 11    Verifying CNA under LKMM using Dartagnan,
     #       applying fixes 1, 2, 3, 4 and 5.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -135,9 +124,9 @@ do
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
         -DFIX1 -DFIX2 -DFIX3 -DFIX4 -DFIX5 \
-        client-code.c | tee results/out12-dartagnan-${solver}-lkmm-cna-both-12345.txt
+        client-code.c | tee results/out11-dartagnan-${solver}-lkmm-cna-both-12345.txt
 
-    # 13    Verifying CNA on Armv8 using Dartagnan,
+    # 12    Verifying CNA on Armv8 using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -145,9 +134,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        client-code.c | tee results/out13-dartagnan-${solver}-armv8-cna-both-none.txt
+        client-code.c | tee results/out12-dartagnan-${solver}-armv8-cna-both-none.txt
 
-    # 14    Verifying CNA on RISC-V using Dartagnan,
+    # 13    Verifying CNA on RISC-V using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -155,9 +144,9 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        client-code.c | tee results/out14-dartagnan-${solver}-riscv-cna-both-none.txt
+        client-code.c | tee results/out13-dartagnan-${solver}-riscv-cna-both-none.txt
 
-    # 15    Verifying qspinlock on Power using Dartagnan,
+    # 14    Verifying qspinlock on Power using Dartagnan,
     #       without applying any fix.
     #       Expect no violation found and result UNKNOWN.
     ./scripts/dartagnan.sh \
@@ -165,6 +154,6 @@ do
         -t ${solver} \
         -p reachability,liveness \
         -DALGORITHM=${CNA_ALGORITHM} \
-        client-code.c | tee results/out15-dartagnan-${solver}-power-cna-both-none.txt
+        client-code.c | tee results/out14-dartagnan-${solver}-power-cna-both-none.txt
 
 done

--- a/verification-commit-recent.patch
+++ b/verification-commit-recent.patch
@@ -1,5 +1,5 @@
 diff --git a/include/asm-generic/qspinlock.h b/include/asm-generic/qspinlock.h
-index d74b138..09a365e 100644
+index d74b138..68ab46d 100644
 --- a/include/asm-generic/qspinlock.h
 +++ b/include/asm-generic/qspinlock.h
 @@ -68,7 +68,11 @@ static __always_inline int queued_spin_trylock(struct qspinlock *lock)
@@ -18,12 +18,11 @@ index d74b138..09a365e 100644
  	if (likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL)))
  		return;
  
--	queued_spin_lock_slowpath(lock, val);
 +#if defined(CONFIG_NUMA_AWARE_SPINLOCKS)
 +	/* We bypass the call (ignoring the boot argument). */
 +	__cna_queued_spin_lock_slowpath(lock, val);
 +#else
-+	queued_spin_lock_slowpath(lock, val);
+ 	queued_spin_lock_slowpath(lock, val);
 +#endif /* defined(CONFIG_NUMA_AWARE_SPINLOCKS) */
  }
  #endif
@@ -77,7 +76,7 @@ index 8c1a21b..70bd251 100644
  
  
 diff --git a/kernel/locking/qspinlock_cna.h b/kernel/locking/qspinlock_cna.h
-index 17d56c7..c828781 100644
+index 17d56c7..0414a3d 100644
 --- a/kernel/locking/qspinlock_cna.h
 +++ b/kernel/locking/qspinlock_cna.h
 @@ -74,7 +74,9 @@ static inline bool intra_node_threshold_reached(struct cna_node *cn)
@@ -125,20 +124,15 @@ index 17d56c7..c828781 100644
  	for_each_possible_cpu(cpu)
  		cna_init_nodes_per_cpu(cpu);
  
-@@ -327,8 +335,11 @@ static __always_inline u32 cna_wait_head_or_lock(struct qspinlock *lock,
+@@ -327,6 +335,7 @@ static __always_inline u32 cna_wait_head_or_lock(struct qspinlock *lock,
  		 * Try and put the time otherwise spent spin waiting on
  		 * _Q_LOCKED_PENDING_MASK to use by sorting our lists.
  		 */
-+		/* NOTE: to speed up verification, we reorder the queue only twice.
++		__VERIFIER_loop_bound(NTHREADS+1);
  		while (LOCK_IS_BUSY(lock) && !cna_order_queue(node))
--			cpu_relax();
-+			cpu_relax(); */
-+		cna_order_queue(node);
-+		cna_order_queue(node);
+ 			cpu_relax();
  	} else {
- 		cn->start_time = FLUSH_SECONDARY_QUEUE;
- 	}
-@@ -376,6 +387,8 @@ static inline void cna_lock_handoff(struct mcs_spinlock *node,
+@@ -376,6 +385,8 @@ static inline void cna_lock_handoff(struct mcs_spinlock *node,
  	arch_mcs_lock_handoff(&next->locked, val);
  }
  
@@ -147,7 +141,7 @@ index 17d56c7..c828781 100644
  /*
   * Constant (boot-param configurable) flag selecting the NUMA-aware variant
   * of spinlock.  Possible values: -1 (off) / 0 (auto, default) / 1 (on).
-@@ -423,3 +436,4 @@ void __init cna_configure_spin_lock_slowpath(void)
+@@ -423,3 +434,4 @@ void __init cna_configure_spin_lock_slowpath(void)
  
  	pr_info("Enabling CNA spinlock\n");
  }


### PR DESCRIPTION
This PR makes the following changes
- `cna_order_queue` is not manually unrolled twice, but rather we use `__VERIFIER_loop_bound`. Since the loop is bounded by the number of threads, this means that we are not removing any code.
- It reverts the change to use marked accesses to initialize the node. This change was introduced when we were still using GenMC.
- It removes `FIX1` because, [as stated by Alan Stern](https://lkml.org/lkml/2022/9/12/447), `FIX2` should also solve the liveness bug.

The verification times are expected to be larger now.